### PR TITLE
Refactor remove near duplicates

### DIFF
--- a/nisapi/clean.py
+++ b/nisapi/clean.py
@@ -1,6 +1,6 @@
 import polars as pl
 import polars.testing
-from typing import Sequence, Callable
+from typing import Sequence
 
 """Data schema to be used for all datasets"""
 data_schema = pl.Schema(

--- a/nisapi/datasets.yaml
+++ b/nisapi/datasets.yaml
@@ -6,7 +6,7 @@
     - One row (national, Pacific Islander, 2023-04-29) has a suppression flag, a null sample size, but a non-null estimate. This row was dropped.
     - "There is a typo column in column names: `estimates` rather than `estimate`"
     - When demographic type is "overall"`, demographic value "18+ years". Clean data changes this value to "overall".
-    - There are some rows that are duplicated, except for point estimate and CIs, which are rounded to different places. Clean data keeps the less precise data.
+    - There are some rows that are duplicated, except for point estimate and CIs, which are rounded to different places. Clean data takes the mean over these rows.
 - id: ksfb-ug5d
   url: https://data.cdc.gov/Vaccinations/Weekly-Cumulative-COVID-19-Vaccination-Coverage-an/ksfb-ug5d/about_data
   vaccine: covid

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,0 +1,50 @@
+import polars as pl
+import polars.testing
+from nisapi.clean import remove_near_duplicates
+
+
+def test_remove_near_duplicates_first():
+    input_df = pl.DataFrame(
+        {
+            "row_id": [1, 2, 3, 4],
+            "group": [1, 1, 2, 2],
+            "value1": [0.0, 0.01, 1.0, 1.01],
+            "value2": [2.0, 2.01, 3.0, 3.01],
+        }
+    )
+
+    current_df = input_df.pipe(
+        remove_near_duplicates,
+        aggregate_function=lambda gb: gb.first(),
+        value_columns=["value1", "value2"],
+        group_columns=["group"],
+        tolerance=1e-1,
+        n_fold_duplication=2,
+    )
+    expected_df = input_df.filter(pl.col("row_id").is_in([1, 3]))
+    polars.testing.assert_frame_equal(current_df, expected_df, check_column_order=False)
+
+
+def test_remove_near_duplicates_round():
+    input_df = pl.DataFrame(
+        {
+            "row_id": [1, 2, 3, 4],
+            "group": [1, 1, 2, 2],
+            "value1": [0.123, 0.1, 1.123, 1.1],
+            "value2": [2.0, 2.01, 3.0, 3.01],
+        }
+    )
+
+    def fewest_sig_figs(df: pl.DataFrame) -> pl.DataFrame:
+        return df.filter(pl.col("value1") == pl.col("value1").round(1))
+
+    current_df = input_df.pipe(
+        remove_near_duplicates,
+        aggregate_function=lambda gb: gb.map_groups(fewest_sig_figs),
+        value_columns=["value1", "value2"],
+        group_columns=["group"],
+        tolerance=1e-1,
+        n_fold_duplication=2,
+    )
+    expected_df = input_df.filter(pl.col("row_id").is_in([2, 4]))
+    polars.testing.assert_frame_equal(current_df, expected_df, check_column_order=False)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,47 +1,74 @@
 import polars as pl
 import polars.testing
-from nisapi.clean import remove_near_duplicates
+from nisapi.clean import remove_near_duplicates, _mean_max_diff
 
 
-def test_remove_near_duplicates_first():
+def test_mean_max_diff():
     input_df = pl.DataFrame(
         {
-            "row_id": [1, 2, 3, 4],
             "group": [1, 1, 2, 2],
-            "value1": [0.0, 0.01, 1.0, 1.01],
+            "value": [0.0, 2.0, 0.0, 20.0],
+        }
+    )
+
+    # all should pass for large tolerance
+    current = input_df.group_by("group").agg(
+        pl.col("value").pipe(_mean_max_diff, tolerance=100.0)
+    )
+    expected = pl.DataFrame({"group": [1, 2], "value": [True, True]})
+    polars.testing.assert_frame_equal(current, expected, check_row_order=False)
+
+    # should fail for small tolerance
+    current = input_df.group_by("group").agg(
+        pl.col("value").pipe(_mean_max_diff, tolerance=2.0)
+    )
+    expected = pl.DataFrame({"group": [1, 2], "value": [True, False]})
+    polars.testing.assert_frame_equal(current, expected, check_row_order=False)
+
+
+def test_remove_near_duplicates_one_value():
+    input_df = pl.DataFrame(
+        {
+            "group": [1, 1, 2, 2],
+            "value1": [0.0, 0.1, 1.0, 1.1],
+            "value2": [2.0, 2.1, 3.0, 3.1],
+        }
+    )
+
+    current_df = input_df.pipe(
+        remove_near_duplicates,
+        value_columns=["value1", "value2"],
+        group_columns=["group"],
+        tolerance=0.1,
+        n_fold_duplication=2,
+    )
+    expected_df = pl.DataFrame(
+        {"group": [1, 2], "value1": [0.05, 1.05], "value2": [2.05, 3.05]}
+    )
+    polars.testing.assert_frame_equal(
+        current_df, expected_df, check_column_order=False, check_row_order=False
+    )
+
+
+def test_remove_near_duplicates_multiple_values():
+    input_df = pl.DataFrame(
+        {
+            "group": [1, 1, 2, 2],
+            "value1": [0.12, 0.1, 1.12, 1.1],
             "value2": [2.0, 2.01, 3.0, 3.01],
         }
     )
 
     current_df = input_df.pipe(
         remove_near_duplicates,
-        filter_expr=pl.col("value1") == pl.col("value1").first(),
         value_columns=["value1", "value2"],
         group_columns=["group"],
-        tolerance=1e-1,
+        tolerance=0.1,
         n_fold_duplication=2,
     )
-    expected_df = input_df.filter(pl.col("row_id").is_in([1, 3]))
-    polars.testing.assert_frame_equal(current_df, expected_df, check_column_order=False)
-
-
-def test_remove_near_duplicates_round():
-    input_df = pl.DataFrame(
-        {
-            "row_id": [1, 2, 3, 4],
-            "group": [1, 1, 2, 2],
-            "value1": [0.123, 0.1, 1.123, 1.1],
-            "value2": [2.0, 2.01, 3.0, 3.01],
-        }
+    expected_df = pl.DataFrame(
+        {"group": [1, 2], "value1": [0.11, 1.11], "value2": [2.005, 3.005]}
     )
-
-    current_df = input_df.pipe(
-        remove_near_duplicates,
-        filter_expr=pl.col("value1") == pl.col("value1").round(1),
-        value_columns=["value1", "value2"],
-        group_columns=["group"],
-        tolerance=1e-1,
-        n_fold_duplication=2,
+    polars.testing.assert_frame_equal(
+        current_df, expected_df, check_column_order=False, check_row_order=False
     )
-    expected_df = input_df.filter(pl.col("row_id").is_in([2, 4]))
-    polars.testing.assert_frame_equal(current_df, expected_df, check_column_order=False)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -15,7 +15,7 @@ def test_remove_near_duplicates_first():
 
     current_df = input_df.pipe(
         remove_near_duplicates,
-        aggregate_function=lambda gb: gb.first(),
+        filter_expr=pl.col("value1") == pl.col("value1").first(),
         value_columns=["value1", "value2"],
         group_columns=["group"],
         tolerance=1e-1,
@@ -35,12 +35,9 @@ def test_remove_near_duplicates_round():
         }
     )
 
-    def fewest_sig_figs(df: pl.DataFrame) -> pl.DataFrame:
-        return df.filter(pl.col("value1") == pl.col("value1").round(1))
-
     current_df = input_df.pipe(
         remove_near_duplicates,
-        aggregate_function=lambda gb: gb.map_groups(fewest_sig_figs),
+        filter_expr=pl.col("value1") == pl.col("value1").round(1),
         value_columns=["value1", "value2"],
         group_columns=["group"],
         tolerance=1e-1,


### PR DESCRIPTION
- Fix bug identified in https://github.com/CDCgov/nis-py-api/pull/7/files#r1846770738
- Add test to verify behavior
- Remove the magic number 2; recharacterize as "fold" duplication
- Refactor removal of near duplicates to take the mean of values over duplicated group rows, checking for some finite tolerance. For example, there are two estimates for one demography/geography/date combination, one of which is 10% and one is 12%, then return 11% (or error out if the tolerance is below 1 percentage point)

Resolves #21 