### PR TITLE
Clean `udsf-9v7b`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,29 @@ Period of time associated with the observation. Note that "monthly" and "weekly"
 
 ## Contributing
 
-See also the [contributing notice](#contributing-standard-notice) below.
-
 ### Adding a new dataset
 
-1. Annotate the dataset ID and URL in `datasets.yaml`
-2. Use a script like `scripts/demo_clean.py` to iterate when formulating the cleaning steps.
+1. Find the dataset you want to clean on <https://data.cdc.gov/>.
+2. Add the dataset to `nisapi/datasets.yaml`.
+   - At a minimum, you must include the dataset ID.
+   - It is helpful to also include URL, vaccine, date range, and universe (i.e., what "overall" demography means).
+3. Create a dataset-specific module in `nisapi/clean/`. It should have a main function `clean()`.
+   - Start with a `clean()` function that does nothing and just returns the input data frame.
+4. Add the `import` and `elif` statements for this dataset ID to `clean_dataset()` in `nisapi/clean/__init__.py`.
+5. Run `scripts/clean_demo.py`. This should cache the raw dataset, run the cleaning function, and fail on validation.
+6. Iteratively update the dataset-specific `clean()` function until validation passes.
+   - Ideally, `clean()` should be a series of pipe functions.
+   - If a cleaning step is shared between datasets, move it into `helpers.py`.
+   - If multiple indicators are redundant, validate that redundancy in code, and then pick only one indicator. (E.g., `ksfb-ug5d` and `sw5n-wg2p` drop the up-to-date indicator in favor of the 4-level vaccination intent indicator.)
+   - If you find some dataset-specific anomaly or validation problem, make a note of it in `datasets.yaml`.
+7. Open a PR.
+   - Include any validations if you needed to correct an anomaly.
 
-When adding a new dataset, include demonstrations that the content of the clean data is what you expected.
+### Standard Notice
+
+Anyone is encouraged to contribute to the repository by [forking](https://help.github.com/articles/fork-a-repo) and submitting a pull request. (If you are new to GitHub, you might start with a [basic tutorial](https://help.github.com/articles/set-up-git).) By contributing to this project, you grant a world-wide, royalty-free, perpetual, irrevocable, non-exclusive, transferable license to all users under the terms of the [Apache Software License v2](http://www.apache.org/licenses/LICENSE-2.0.html) or later.
+
+All comments, messages, pull requests, and other submissions received through CDC including this GitHub page may be subject to applicable federal law, including but not limited to the Federal Records Act, and may be archived. Learn more at [http://www.cdc.gov/other/privacy.html](http://www.cdc.gov/other/privacy.html).
 
 ## Project Admin
 
@@ -124,12 +139,6 @@ This repository is licensed under [ASL v2](http://www.apache.org/licenses/LICENS
 ## Privacy Standard Notice
 
 This repository contains only non-sensitive, publicly available data and information. All material and community participation is covered by the [Disclaimer](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md) and [Code of Conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md). For more information about CDC's privacy policy, please visit [http://www.cdc.gov/other/privacy.html](https://www.cdc.gov/other/privacy.html).
-
-## Contributing Standard Notice
-
-Anyone is encouraged to contribute to the repository by [forking](https://help.github.com/articles/fork-a-repo) and submitting a pull request. (If you are new to GitHub, you might start with a [basic tutorial](https://help.github.com/articles/set-up-git).) By contributing to this project, you grant a world-wide, royalty-free, perpetual, irrevocable, non-exclusive, transferable license to all users under the terms of the [Apache Software License v2](http://www.apache.org/licenses/LICENSE-2.0.html) or later.
-
-All comments, messages, pull requests, and other submissions received through CDC including this GitHub page may be subject to applicable federal law, including but not limited to the Federal Records Act, and may be archived. Learn more at [http://www.cdc.gov/other/privacy.html](http://www.cdc.gov/other/privacy.html).
 
 ## Records Management Standard Notice
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Rows that were suppressed in the raw data are dropped. This includes data with s
 ### `demographic_type`
 
 - There are multiple types, including `"overall"` and `"age"`
-- Note that "overall" might refer only to certain age groups (e.g., 18+)
+- Note that "overall" might refer only to certain age groups (e.g., 18+). See the dataset metadata for the relevant universe.
 
 ### `demographic_value`
 
@@ -68,7 +68,8 @@ Rows that were suppressed in the raw data are dropped. This includes data with s
 
 ### `indicator_type`
 
-- Always `"4-level vaccination and intent"`
+- In newer data, this is always `"4-level vaccination and intent"`
+- In historical COVID-19 data, there are a wide range of indicators
 
 ### `indicator_value`
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Period of time associated with the observation. Note that "monthly" and "weekly"
 5. Run `scripts/clean_demo.py`. This should cache the raw dataset, run the cleaning function, and fail on validation.
 6. Iteratively update the dataset-specific `clean()` function until validation passes.
    - Ideally, `clean()` should be a series of pipe functions.
-   - If a cleaning step is shared between datasets, move it into `helpers.py`.
+   - If a cleaning step is specific to a single dataset, keep that in the dataset-specific submodule. If a step is shared between datasets, move it into `helpers.py`.
    - If multiple indicators are redundant, validate that redundancy in code, and then pick only one indicator. (E.g., `ksfb-ug5d` and `sw5n-wg2p` drop the up-to-date indicator in favor of the 4-level vaccination intent indicator.)
    - If you find some dataset-specific anomaly or validation problem, make a note of it in `datasets.yaml`.
 7. Open a PR.

--- a/nisapi/clean/__init__.py
+++ b/nisapi/clean/__init__.py
@@ -37,10 +37,9 @@ def clean_dataset(df: pl.DataFrame, id: str) -> pl.DataFrame:
 
 
 class Validate:
-    def __init__(self, id: str, df: pl.DataFrame):
-        assert isinstance(df, pl.DataFrame)
+    def __init__(self, id: str, df: pl.DataFrame | pl.LazyFrame):
         self.id = id
-        self.df = df
+        self.df = df.pipe(ensure_eager)
         self.validate()
 
     def validate(self):

--- a/nisapi/clean/__init__.py
+++ b/nisapi/clean/__init__.py
@@ -1,6 +1,7 @@
 import polars as pl
 import polars.testing
 import nisapi.clean.ksfb_ug5d
+import nisapi.clean.udsf_9v7b
 import nisapi.clean.sw5n_wg2p
 from nisapi.clean.helpers import (
     is_valid_age_groups,
@@ -21,7 +22,9 @@ def clean_dataset(df: pl.DataFrame, id: str) -> pl.DataFrame:
         pl.DataFrame: clean dataset
     """
 
-    if id == "sw5n-wg2p":
+    if id == "udsf-9v7b":
+        out = nisapi.clean.udsf_9v7b.clean(df)
+    elif id == "sw5n-wg2p":
         out = nisapi.clean.sw5n_wg2p.clean(df)
     elif id == "ksfb-ug5d":
         out = nisapi.clean.ksfb_ug5d.clean(df)

--- a/nisapi/clean/helpers.py
+++ b/nisapi/clean/helpers.py
@@ -395,3 +395,31 @@ def enforce_columns(df: pl.LazyFrame, schema: pl.Schema = data_schema) -> pl.Laz
     if missing_columns != set():
         raise RuntimeError("Missing columns:", missing_columns)
     return df.select(needed_columns)
+
+
+def duplicated_rows(df: pl.DataFrame) -> pl.DataFrame:
+    """Return duplicated rows of an (eager) data frame
+
+    Args:
+        df (pl.DataFrame): input df
+
+    Returns:
+        pl.DataFrame: duplicated rows only
+    """
+    return df.filter(df.is_duplicated())
+
+
+def rows_with_any_null(df: pl.LazyFrame) -> pl.LazyFrame:
+    """Filter a data frame for rows with any null value
+
+    Args:
+        df (pl.LazyFrame): data frame
+
+    Returns:
+        pl.LazyFrame: rows with any null value
+    """
+    col_name = "any"
+    rows = df.select(pl.all().is_null()).select(
+        pl.any_horizontal(pl.all()).alias(col_name)
+    )[col_name]
+    return df.filter(rows)

--- a/nisapi/clean/udsf_9v7b.py
+++ b/nisapi/clean/udsf_9v7b.py
@@ -1,0 +1,129 @@
+import polars as pl
+import uuid
+import calendar
+from nisapi.clean.helpers import admin1_values, drop_suppressed_rows
+
+
+def _clean_geography_expr(type_: pl.Expr, value: pl.Expr) -> pl.Expr:
+    out_type = (
+        pl.when(type_ == pl.lit("National Estimates"))
+        .then(pl.lit("nation"))
+        .when(type_ == pl.lit("HHS Regional Estimates"))
+        .then(pl.lit("region"))
+        .when(
+            (type_ == pl.lit("Jurisdictional Estimates")) & (value.is_in(admin1_values))
+        )
+        .then(pl.lit("admin1"))
+        .when(
+            (type_ == pl.lit("Jurisdictional Estimates"))
+            & (value.str.contains(r"^[A-Z]{2}-"))
+        )
+        .then(pl.lit("substate"))
+    )
+
+    out_value = (
+        pl.when(out_type == pl.lit("nation"))
+        .then(pl.lit("nation"))
+        .when(out_type == pl.lit("region"))
+        .then(value.pipe(clean_region))
+        .when(out_type.is_in(["admin1", "substate"]))
+        .then(value)
+    )
+
+    return pl.struct(geographic_type=out_type, geographic_value=out_value)
+
+
+def clean_geography(df: pl.DataFrame) -> pl.DataFrame:
+    geography_column = str(uuid.uuid1())
+    return (
+        df.with_columns(
+            _clean_geography_expr(
+                pl.col("geographic_type"), pl.col("geographic_value")
+            ).alias(geography_column)
+        )
+        .drop(["geographic_type", "geographic_value"])
+        .unnest(geography_column)
+    )
+
+
+def clean_age_group(x: pl.Expr) -> pl.Expr:
+    return x.str.replace(" – ", "-")
+
+
+def clean_region(x: pl.Expr) -> pl.Expr:
+    return x.str.extract("^(Region \\d+): ", 1)
+
+
+def parse_coninf_95(df: pl.DataFrame) -> pl.DataFrame:
+    df_split = df.with_columns(
+        pl.col("coninf_95")
+        .str.split_exact(" - ", 1)
+        .struct.rename_fields(["lci", "uci"])
+    )
+
+    return df_split.unnest("coninf_95")
+
+
+def month_name_to_number(x: pl.Expr) -> pl.Expr:
+    # note that we need to do this union because "May" is both a full name and an abbreviation,
+    # and replace_strict wants unique old values. Note also that range(13) includes 0, and
+    # month_name[0] is ""
+    mapping = dict(zip(calendar.month_name, range(13))) | dict(
+        zip(calendar.month_abbr, range(13))
+    )
+    return x.replace_strict(mapping)
+
+
+def _parse_time_period_expr(time_year: pl.Expr, time_period: pl.Expr) -> pl.Expr:
+    year = time_year.cast(pl.Int32)
+    period_split = time_period.str.extract_groups(
+        r"^(\w+)\s+(\w+)\s+-\s+(\w+)\s+(\w+)\s*$"
+    ).struct.rename_fields(["month1", "day1", "month2", "day2"])
+
+    month1 = period_split.struct["month1"].pipe(month_name_to_number)
+    day1 = period_split.struct["day1"].str.strip_chars().cast(pl.Int32)
+    month2 = period_split.struct["month2"].pipe(month_name_to_number)
+    day2 = period_split.struct["day2"].str.strip_chars().cast(pl.Int32)
+
+    date1 = pl.date(year, month1, day1)
+    date2 = pl.date(year, month2, day2)
+
+    return pl.struct(start=date1, end=date2)
+
+
+def parse_time_period(df: pl.DataFrame) -> pl.DataFrame:
+    column_name = str(uuid.uuid1())
+    return (
+        df.with_columns(
+            _parse_time_period_expr(pl.col("time_year"), pl.col("time_period")).alias(
+                column_name
+            )
+        )
+        .unnest(column_name)
+        .drop(["time_year", "time_period"])
+    )
+
+
+def clean(df: pl.LazyFrame) -> pl.LazyFrame:
+    return (
+        df.rename(
+            {
+                "geography_type": "geographic_type",
+                "geography": "geographic_value",
+                "group_name": "demographic_type",
+                "group_category": "demographic_value",
+                "indicator_name": "indicator_type",
+                "indicator_category": "indicator_value",
+            }
+        )
+        .pipe(drop_suppressed_rows)
+        .drop("sample_size")
+        .pipe(parse_coninf_95)
+        .pipe(parse_time_period)
+        .with_columns(
+            pl.col("time_type").replace_strict({"Monthly": "month", "Weekly": "week"})
+        )
+        .with_columns(pl.col(["estimate", "lci", "uci"]).cast(pl.Float64))
+        .with_columns(pl.col("demographic_value").pipe(clean_age_group))
+        .pipe(clean_geography)
+    )

--- a/nisapi/datasets.yaml
+++ b/nisapi/datasets.yaml
@@ -19,6 +19,14 @@
     - There are some rows that are duplicated, except for point estimate and CIs, which are rounded to different places. Clean data takes the mean over these rows.
 - id: udsf-9v7b
   url: https://data.cdc.gov/Vaccinations/National-Immunization-Survey-Adult-COVID-Module-NI/udsf-9v7b/about_data
+  vaccine: covid
   start_date: 2021-04-22
   end_date: 2023-04-01
-  vaccine: covid
+  universe: 18+ years old
+  notes:
+    - Suppression flags:
+        - All null-estimate and "1"-flagged rows were dropped.
+        - "16 rows have the expected pattern: flag '1' and a null value."
+        - 12 rows have sample size < 30, and they all have flag "0".
+        - 1399 rows have flag "1" but non-null estimates.
+        - Suppression flags include non-standard value "0.0".

--- a/nisapi/datasets.yaml
+++ b/nisapi/datasets.yaml
@@ -17,4 +17,6 @@
     - There are some rows that are duplicated, except for point estimate and CIs, which are rounded to different places. Clean data takes the mean over these rows.
 - id: udsf-9v7b
   url: https://data.cdc.gov/Vaccinations/National-Immunization-Survey-Adult-COVID-Module-NI/udsf-9v7b/about_data
+  start_date: 2021-04-22
+  end_date: 2023-04-01
   vaccine: covid

--- a/nisapi/datasets.yaml
+++ b/nisapi/datasets.yaml
@@ -15,3 +15,6 @@
   notes:
     - When demographic type is "overall"`, demographic value "18+ years". Clean data changes this value to "overall".
     - There are some rows that are duplicated, except for point estimate and CIs, which are rounded to different places. Clean data takes the mean over these rows.
+- id: udsf-9v7b
+  url: https://data.cdc.gov/Vaccinations/National-Immunization-Survey-Adult-COVID-Module-NI/udsf-9v7b/about_data
+  vaccine: covid

--- a/nisapi/datasets.yaml
+++ b/nisapi/datasets.yaml
@@ -1,6 +1,7 @@
 - id: sw5n-wg2p
   url: https://data.cdc.gov/Flu-Vaccinations/Weekly-Influenza-Vaccination-Coverage-and-Intent-f/sw5n-wg2p/
   vaccine: flu
+  universe: 18+ years old
   start_date: 2021-10-02
   notes:
     - One row (national, Pacific Islander, 2023-04-29) has a suppression flag, a null sample size, but a non-null estimate. This row was dropped.
@@ -12,6 +13,7 @@
   url: https://data.cdc.gov/Vaccinations/Weekly-Cumulative-COVID-19-Vaccination-Coverage-an/ksfb-ug5d/about_data
   vaccine: covid
   start_date: 2021-10-02
+  universe: 18+ years old
   notes:
     - When demographic type is "overall"`, demographic value "18+ years". Clean data changes this value to "overall".
     - There are some rows that are duplicated, except for point estimate and CIs, which are rounded to different places. Clean data takes the mean over these rows.

--- a/nisapi/socrata.py
+++ b/nisapi/socrata.py
@@ -1,4 +1,18 @@
 import requests
+import math
+from typing import Sequence
+
+domain = "data.cdc.gov"
+
+
+def n_dataset_rows(id: str, app_token: str = None, domain: str = domain) -> int:
+    url = f"https://{domain}/resource/{id}.json?$select=count(:id)"
+    r = _get_request(url, app_token=app_token)
+
+    result = r.json()
+    assert len(result) == 1
+    assert "count_id" in result[0]
+    return int(result[0]["count_id"])
 
 
 def download_dataset_records(
@@ -6,8 +20,8 @@ def download_dataset_records(
     start_record: int,
     end_record: int,
     app_token: str = None,
-    format: str = "json",
-):
+    domain: str = domain,
+) -> list[dict]:
     """Download a specific range of rows of a data.cdc.gov dataset
 
     Args:
@@ -15,54 +29,68 @@ def download_dataset_records(
         start_record (int): first row (zero-indexed)
         end_record (int): last row (zero-indexed)
         app_token (str, optional): Socrata developer app token. Defaults to None.
-        format (str, optional): "json" or "csv". Defaults to "json".
+        domain (str, optional): defaults to "data.cdc.gov"
 
     Returns:
         If format is "json", a list. If "csv", then a string
     """
-    payload = {}
-    if app_token is not None:
-        payload["X-App-token"] = app_token
 
     assert end_record >= start_record
     limit = end_record - start_record + 1
 
-    format = "json"
+    url = f"https://{domain}/resource/{id}.json?$limit={limit}&$offset={start_record}&$order=:id"
+    r = _get_request(url, app_token=app_token)
 
-    url = f"https://data.cdc.gov/resource/{id}.{format}?$limit={limit}&$offset={start_record}"
+    return r.json()
+
+
+def _get_request(url: str, app_token: str = None) -> requests.Request:
+    payload = {}
+    if app_token is not None:
+        payload["X-App-token"] = app_token
+
     r = requests.get(url, data=payload)
-
     if r.status_code == 200:
-        if format == "json":
-            return r.json()
-        else:
-            return r.text
+        return r
     else:
-        raise RuntimeError(f"HTTP request failure: {r.status_code}")
+        raise RuntimeError(
+            f"HTTP request failure: url '{url}' failed with code {r.status_code}"
+        )
 
 
-def download_dataset_pages(id: str, page_size: int = int(1e6), app_token: str = None):
+def download_dataset_pages(
+    id: str, page_size: int = int(1e5), app_token: str = None, verbose: bool = True
+) -> Sequence[list[dict]]:
     """Download a dataset page by page
 
     Args:
         id (str): dataset ID
         page_size (int, optional): Page size. Defaults to 1 million.
         app_token (str, optional): Socrata developer app token. Defaults to None.
+        verbose (bool): If True (default), print progress
 
     Yields:
         Sequence of objects returned by download_dataset_records()
     """
-    i = 0
-    page = None
-    while page != []:
-        start_record = page_size * i
-        end_record = start_record + page_size - 1
+    n_rows = n_dataset_rows(id, app_token=app_token)
+    n_pages = math.ceil(n_rows / page_size)
+
+    if verbose:
+        print(
+            f"Downloading dataset {id=}: {n_rows} rows in {n_pages} page(s) of {page_size} rows each"
+        )
+
+    for i in range(n_pages):
+        if verbose:
+            print(f"  Downloading page {i + 1}/{n_pages}")
+
+        start_record = i * page_size
+        end_record = (i + 1) * page_size - 1
         page = download_dataset_records(
             id, start_record=start_record, end_record=end_record, app_token=app_token
         )
-        i += 1
 
-        if page == []:
-            break
-        else:
-            yield page
+        assert len(page) > 0
+        assert len(page) <= page_size
+
+        yield page

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -28,8 +28,9 @@ df = (
         "indicator_type",
         "indicator_value",
     )
+    # get the first few rows
+    .head(10)
     .collect()
 )
 
-# Print the first few rows
 print(df)

--- a/scripts/demo_clean.py
+++ b/scripts/demo_clean.py
@@ -6,17 +6,27 @@ import nisapi.clean.udsf_9v7b
 import altair as alt
 
 dataset_id = "udsf-9v7b"
+clean_func = nisapi.clean.udsf_9v7b.clean
+clean_tmp_path = "scripts/tmp_clean.parquet"
 
 with open("scripts/secrets.yaml") as f:
     app_token = yaml.safe_load(f)["app_token"]
 
 raw = nisapi._get_nis_raw(id=dataset_id, app_token=app_token)
 
+# show the first few rows of the raw data
 raw.head().collect().glimpse()
 
-clean = nisapi.clean.udsf_9v7b.clean(raw)
+# try to clean the data
+clean = clean_func(raw)
+
+# look at the first few rows of the partially cleaned data
 clean.head(10).collect().glimpse()
 
+# save a copy of the partially cleaned data
+clean.collect().write_parquet(clean_tmp_path)
+
+# this will fail until the dataset cleaning is complete
 Validate(id=dataset_id, df=clean)
 
 alt.Chart(

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -4,6 +4,7 @@ from nisapi.clean.helpers import (
     remove_near_duplicates,
     _mean_max_diff,
     is_valid_age_groups,
+    rows_with_any_null,
 )
 
 
@@ -93,3 +94,13 @@ def test_validate_age_groups():
 
     # fail if there are spaces
     assert not is_valid_age_groups(pl.Series(["18 - 49 years"]))
+
+
+def test_row_has_null():
+    df = pl.DataFrame(
+        {"id": [1, 2, 3, 4], "x": [None, None, 3, 4], "y": [1, None, None, 4]}
+    )
+    current = df.pipe(rows_with_any_null)
+    expected = df.filter(pl.col("id").is_in([1, 2, 3]))
+
+    polars.testing.assert_frame_equal(current, expected)


### PR DESCRIPTION
- [x] Improve paging system, to avoid a memory leak/crash. Now the downloaded pages are written to disk and only read into a single, raw file at the end of the process. (I don't download directly to the raw cache, to ensure atomiticity.)
- [x] Remove indicator validation (cf. #16 )
- [x] Change group type "All adults 18+" (and corresponding group value "All adult 18+ years") into "overall"


## Out of scope

- Update schema to `group_type` and `group_value`, since these data include not only demography (eg age, race) but also things that could be otherwise called indicators (e.g., sentiment). (punted to #40 )
- Normalize all strings to (1) remove starting and trailing whitespace, (2) compact multiple internal spaces to a single space, and (3) apply lower case. (punted to #41 )
- Add this string normalization also to validation (punted to #41 )

Resolves #24 