### PR TITLE
Rename 'demography' as 'domain'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,21 @@ Python API to the National Immunization Survey (NIS) data.
 
 The data have these columns, in order, with these types:
 
-| column              | type    |
-| ------------------- | ------- |
-| `vaccine`           | String  |
-| `geographic_type`   | String  |
-| `geographic_value`  | String  |
-| `demographic_type`  | String  |
-| `demographic_value` | String  |
-| `indicator_type`    | String  |
-| `indicator_value`   | String  |
-| `time_type`         | String  |
-| `time_start`        | Date    |
-| `time_end`          | Date    |
-| `estimate`          | Float64 |
-| `lci`               | Float64 |
-| `uci`               | Float64 |
+| column             | type    |
+| ------------------ | ------- |
+| `vaccine`          | String  |
+| `geographic_type`  | String  |
+| `geographic_value` | String  |
+| `domain_type`      | String  |
+| `domain_value`     | String  |
+| `indicator_type`   | String  |
+| `indicator_value`  | String  |
+| `time_type`        | String  |
+| `time_start`       | Date    |
+| `time_end`         | Date    |
+| `estimate`         | Float64 |
+| `lci`              | Float64 |
+| `uci`              | Float64 |
 
 Note the paired use of "type" and "value" columns.
 
@@ -63,13 +63,13 @@ Rows that were suppressed in the raw data are dropped. This includes data with s
 - If `"substate"`, no validation is currently applied
 - If `"county"`, then the 5-digit FIPS code
 
-### `demographic_type`
+### `domain_type`
 
 - There are multiple types, including `"age"`
 
-### `demographic_value`
+### `domain_value`
 
-- If `demographic_type` is `"age"`, then this is the age group, with the form `"x-y years"` or `"x+ years"`
+- If `domain_type` is `"age"`, then this is the age group, with the form `"x-y years"` or `"x+ years"`
 
 ### `indicator_type`
 
@@ -92,7 +92,7 @@ Period of time associated with the observation. Note that "monthly" and "weekly"
 
 ### `estimate`
 
-- Proportion (i.e., a number between 0 and 1) of the population (defined by geography and demography) that has the characteristic described by the indicator
+- Proportion (i.e., a number between 0 and 1) of the population (defined by geography and domain) that has the characteristic described by the indicator
 
 ### `lci` and `uci`
 

--- a/nisapi/clean/__init__.py
+++ b/nisapi/clean/__init__.py
@@ -95,10 +95,10 @@ class Validate:
             df, type_column="geographic_type", value_column="geographic_value"
         )
 
-        # Demographics ------------------------------------------------------------
+        # domains ------------------------------------------------------------
         # age groups should have the form "18-49 years" or "65+ years"
-        age_groups = df.filter(pl.col("demographic_type") == pl.lit("age"))[
-            "demographic_value"
+        age_groups = df.filter(pl.col("domain_type") == pl.lit("age"))[
+            "domain_value"
         ].unique()
         invalid_age_groups = age_groups.filter(
             cls.is_valid_age_group(age_groups).not_()

--- a/nisapi/clean/helpers.py
+++ b/nisapi/clean/helpers.py
@@ -9,8 +9,8 @@ data_schema = pl.Schema(
         ("vaccine", pl.String),
         ("geographic_type", pl.String),
         ("geographic_value", pl.String),
-        ("demographic_type", pl.String),
-        ("demographic_value", pl.String),
+        ("domain_type", pl.String),
+        ("domain_value", pl.String),
         ("indicator_type", pl.String),
         ("indicator_value", pl.String),
         ("time_type", pl.String),
@@ -120,7 +120,7 @@ def set_lowercase(df: pl.LazyFrame) -> pl.LazyFrame:
             [
                 "vaccine",
                 "geographic_type",
-                "demographic_type",
+                "domain_type",
                 "indicator_value",
                 "indicator_type",
             ]
@@ -171,14 +171,14 @@ def remove_duplicate_rows(df: pl.LazyFrame) -> pl.LazyFrame:
 def rename_indicator_columns(df: pl.DataFrame) -> pl.DataFrame:
     """
     Make "indicator" follow the same logic as "geography" and
-    "demographic", with "type" and "value" columns
+    "domain", with "type" and "value" columns
     """
     return df.rename(
         {
             "geographic_level": "geographic_type",
             "geographic_name": "geographic_value",
-            "demographic_level": "demographic_type",
-            "demographic_name": "demographic_value",
+            "demographic_level": "domain_type",
+            "demographic_name": "domain_value",
             "indicator_label": "indicator_type",
             "indicator_category_label": "indicator_value",
         }
@@ -257,8 +257,8 @@ def remove_near_duplicates(
     return df.group_by(group_columns).agg(pl.col(value_columns).mean())
 
 
-def replace_overall_demographic_value(df: pl.LazyFrame) -> pl.LazyFrame:
-    return df.with_columns(pl.col("demographic_type").replace({"overall": "age"}))
+def replace_overall_domain_value(df: pl.LazyFrame) -> pl.LazyFrame:
+    return df.with_columns(pl.col("domain_type").replace({"overall": "age"}))
 
 
 def _mean_max_diff(x: pl.Expr, tolerance: float) -> pl.Expr:

--- a/nisapi/clean/ksfb_ug5d.py
+++ b/nisapi/clean/ksfb_ug5d.py
@@ -1,16 +1,17 @@
 import polars as pl
+
 from nisapi.clean.helpers import (
-    drop_suppressed_rows,
-    rename_indicator_columns,
-    set_lowercase,
     cast_types,
-    clean_geography,
     clean_4_level,
-    remove_near_duplicates,
-    replace_overall_demographic_value,
-    week_ending_to_times,
-    hci_to_cis,
+    clean_geography,
+    drop_suppressed_rows,
     enforce_columns,
+    hci_to_cis,
+    remove_near_duplicates,
+    rename_indicator_columns,
+    replace_overall_domain_value,
+    set_lowercase,
+    week_ending_to_times,
 )
 
 
@@ -27,5 +28,5 @@ def clean(df: pl.LazyFrame) -> pl.LazyFrame:
         .pipe(week_ending_to_times)
         .pipe(hci_to_cis)
         .pipe(enforce_columns)
-        .pipe(replace_overall_demographic_value)
+        .pipe(replace_overall_domain_value)
     )

--- a/nisapi/clean/sw5n_wg2p.py
+++ b/nisapi/clean/sw5n_wg2p.py
@@ -1,16 +1,17 @@
 import polars as pl
+
 from nisapi.clean.helpers import (
-    drop_suppressed_rows,
-    rename_indicator_columns,
-    set_lowercase,
     cast_types,
-    clean_geography,
-    remove_near_duplicates,
     clean_4_level,
-    replace_overall_demographic_value,
-    week_ending_to_times,
-    hci_to_cis,
+    clean_geography,
+    drop_suppressed_rows,
     enforce_columns,
+    hci_to_cis,
+    remove_near_duplicates,
+    rename_indicator_columns,
+    replace_overall_domain_value,
+    set_lowercase,
+    week_ending_to_times,
 )
 
 
@@ -25,7 +26,7 @@ def clean(df: pl.LazyFrame) -> pl.LazyFrame:
         .pipe(set_lowercase)
         .pipe(cast_types)
         .pipe(clean_geography)
-        .pipe(replace_overall_demographic_value)
+        .pipe(replace_overall_domain_value)
         .pipe(remove_near_duplicates, tolerance=1e-3, n_fold_duplication=2)
         .pipe(clean_4_level)
         .pipe(week_ending_to_times)

--- a/nisapi/clean/udsf_9v7b.py
+++ b/nisapi/clean/udsf_9v7b.py
@@ -1,6 +1,8 @@
-import polars as pl
-import uuid
 import calendar
+import uuid
+
+import polars as pl
+
 from nisapi.clean.helpers import admin1_values, drop_suppressed_rows, enforce_columns
 
 
@@ -104,21 +106,21 @@ def parse_time_period(df: pl.DataFrame) -> pl.DataFrame:
     )
 
 
-def enforce_overall_demography(df: pl.LazyFrame) -> pl.LazyFrame:
+def enforce_overall_domain(df: pl.LazyFrame) -> pl.LazyFrame:
     """
-    Replace overall demographic type ("All adults 18+") and value
+    Replace overall domain type ("All adults 18+") and value
     ("All adults age 18+ years") with "overall"
     """
     return df.with_columns(
-        pl.when(pl.col("demographic_type") == pl.lit("All adults 18+"))
+        pl.when(pl.col("domain_type") == pl.lit("All adults 18+"))
         .then(pl.lit("overall"))
-        .otherwise(pl.col("demographic_type"))
-        .alias("demographic_type"),
+        .otherwise(pl.col("domain_type"))
+        .alias("domain_type"),
     ).with_columns(
-        pl.when(pl.col("demographic_type") == pl.lit("overall"))
+        pl.when(pl.col("domain_type") == pl.lit("overall"))
         .then(pl.lit("overall"))
-        .otherwise(pl.col("demographic_value"))
-        .alias("demographic_value")
+        .otherwise(pl.col("domain_value"))
+        .alias("domain_value")
     )
 
 
@@ -128,8 +130,8 @@ def clean(df: pl.LazyFrame) -> pl.LazyFrame:
             {
                 "geography_type": "geographic_type",
                 "geography": "geographic_value",
-                "group_name": "demographic_type",
-                "group_category": "demographic_value",
+                "group_name": "domain_type",
+                "group_category": "domain_value",
                 "indicator_name": "indicator_type",
                 "indicator_category": "indicator_value",
             }
@@ -143,8 +145,8 @@ def clean(df: pl.LazyFrame) -> pl.LazyFrame:
         .with_columns(
             pl.col("time_type").replace_strict({"Monthly": "month", "Weekly": "week"})
         )
-        .with_columns(pl.col("demographic_value").pipe(clean_age_group))
-        .pipe(enforce_overall_demography)
+        .with_columns(pl.col("domain_value").pipe(clean_age_group))
+        .pipe(enforce_overall_domain)
         .pipe(clean_geography)
         .pipe(enforce_columns)
         # drop duplicate rows

--- a/nisapi/datasets.yaml
+++ b/nisapi/datasets.yaml
@@ -6,7 +6,7 @@
   notes:
     - One row (national, Pacific Islander, 2023-04-29) has a suppression flag, a null sample size, but a non-null estimate. This row was dropped.
     - "There is a typo column in column names: `estimates` rather than `estimate`"
-    - When demographic type is "overall"`, demographic value "18+ years". Clean data changes this value to "overall".
+    - When domain type is "overall"`, domain value is "18+ years". Clean data changes this value to "age".
     - There are some rows that are duplicated, except for point estimate and CIs, which are rounded to different places. Clean data takes the mean over these rows.
     - In some cases, the estimate minus the half 95% CI yields a value lower than 0. In those cases, the lower bound is replaced with zero.
 - id: ksfb-ug5d
@@ -15,7 +15,7 @@
   start_date: 2023-09-24
   universe: 18+ years old
   notes:
-    - When demographic type is "overall"`, demographic value "18+ years". Clean data changes this value to "overall".
+    - When domain type is "overall"`, domain value is "18+ years". Clean data changes this value to "age".
     - There are some rows that are duplicated, except for point estimate and CIs, which are rounded to different places. Clean data takes the mean over these rows.
 - id: udsf-9v7b
   url: https://data.cdc.gov/Vaccinations/National-Immunization-Survey-Adult-COVID-Module-NI/udsf-9v7b/about_data

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -18,16 +18,9 @@ nisapi.cache_all_datasets(app_token=app_token)
         # national data
         pl.col("geographic_type") == pl.lit("nation"),
         # by age group
-        pl.col("demographic_type") == pl.lit("age"),
+        pl.col("domain_type") == pl.lit("age"),
         # showing %vaccinated through time
         pl.col("indicator_value") == pl.lit("received a vaccination"),
-    )
-    .drop(
-        "geographic_type",
-        "geographic_value",
-        "demographic_type",
-        "indicator_type",
-        "indicator_value",
     )
     # get the first few rows
     .head(10)

--- a/scripts/demo_clean.py
+++ b/scripts/demo_clean.py
@@ -40,7 +40,7 @@ def date_to_season(date: pl.Expr) -> pl.Expr:
 alt.Chart(
     clean.filter(
         pl.col("geographic_type") == pl.lit("nation"),
-        pl.col("demographic_value") == "18+ years",
+        pl.col("domain_value") == "18+ years",
         pl.col("indicator_value") == "received a vaccination",
     )
     .with_columns(season=date_to_season(pl.col("time_end")))

--- a/scripts/demo_streamlit.py
+++ b/scripts/demo_streamlit.py
@@ -45,8 +45,8 @@ if __name__ == "__main__":
             options=["nation", "region", "admin1", "substate"],
         )
         .pipe(widget_filter, "geographic_value")
-        .pipe(widget_filter, "demographic_type", default="age")
-        .pipe(widget_filter, "demographic_value", default="18+ years")
+        .pipe(widget_filter, "domain_type", default="age")
+        .pipe(widget_filter, "domain_value", default="18+ years")
         .pipe(widget_filter, "time_type", default="week")
         .pipe(widget_filter, "indicator_type", default="4-level vaccination and intent")
         .pipe(widget_filter, "indicator_value", default="received a vaccination")


### PR DESCRIPTION
"Domain" is more accurate because some groupings are not demography, and "domain" is the broader survey jargon for subgroup that has an estimate.

Resolves #40 