### PR TITLE
Warnings instead of errors when some validations fail

### DIFF
--- a/nisapi/clean/__init__.py
+++ b/nisapi/clean/__init__.py
@@ -48,15 +48,18 @@ class Validate:
         self.validate()
 
     def validate(self):
-        self.errors = self.get_validation_errors(self.df)
-        if len(self.errors) > 0:
+        self.problems = self.get_validation_problems(self.df)
+        if len(self.problems["warnings"]) > 0:
+            print(f"Validation warnings in dataset ID: {self.id}")
+            print(*self.problems["warnings"], sep="\n")
+        if len(self.problems["errors"]) > 0:
             print(f"Validation errors in dataset ID: {self.id}")
-            print(*self.errors, sep="\n")
+            print(*self.problems["errors"], sep="\n")
 
             raise RuntimeError("Validation errors")
 
     @classmethod
-    def get_validation_errors(cls, df: pl.DataFrame):
+    def get_validation_problems(cls, df: pl.DataFrame):
         errors = []
         warnings = []
 
@@ -131,7 +134,7 @@ class Validate:
         if not ((df["lci"] <= df["estimate"]) & (df["estimate"] <= df["uci"])).all():
             errors.append("confidence intervals do not bracket estimate")
 
-        return errors
+        return {"errors": errors, "warnings": warnings}
 
     @staticmethod
     def validate_vaccine(df: pl.DataFrame, column: str) -> [str]:


### PR DESCRIPTION
I am trying to run NIS API to make sure I have the most up-to-date data, but some of the most recent data fails validation. In particular, two data points have an upper confidence interval > 1.0:

![image](https://github.com/user-attachments/assets/e48c14bc-425a-4213-a62e-3c7261657239)

This causes an error, such that `cache_all_datasets` stops, so I cannot acquire the data. One solution might be to have some failed validations create warnings rather than errors. This way, the user is alerted but not blocked from acquiring the data.