### PR TITLE
Add simple CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Python API to access parts of the [National Immunization Survey](https://www.cdc
 - See `scripts/demo.py` for an example of how to cache and query the data:
   - `python -m nisapi cache_all` or `nisapi.cache_all_datasets()` to download, clean, and cache data
   - `nisapi.get_nis()` to get a lazy data frame pointing to that locally cached, clean data
-  - `python -m nisapi clear` or `nisapi.delete_cache()` to clear the cache, if needed
+  - `python -m nisapi delete` or `nisapi.delete_cache()` to delete the cache, if needed
 - See `scripts/demo_clean.py` for an example of a script that you could run while iteratively developing the cleaning code in `nisapi/clean/`.
 - See `scripts/demo_cloud.py` for a demo of how the data could be downloaded, cleaned, uploaded to Azure Blob Storage, and then downloaded from there. You will need to fill out the `azure:` keys in `secrets.yaml`.
 - Run `streamlit run scripts/demo_streamlit.py` to quickly query and visualize the data with a [streamlit](https://streamlit.io/) app.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@ Python API to access parts of the [National Immunization Survey](https://www.cdc
 
 ## Getting started
 
-- This a poetry-enabled project. Use `poetry install` to install.
-- Get a [Socrata app token](https://support.socrata.com/hc/en-us/articles/210138558-Generating-App-Tokens-and-API-Keys). Copy `scripts/secrets_template.yaml` to `scripts/secrets.yaml` and fill out the `app_token`.
-- See `scripts/demo.py` for an example of how to cache and query the data:
-  - `python -m nisapi cache app_token={SOCRATA_APP_TOKEN}` or `nisapi.cache_all_datasets(app_token={SOCRATA_APP_TOKEN})` to download, clean, and cache data
-  - `nisapi.get_nis()` to get a lazy data frame pointing to that locally cached, clean data
-  - `python -m nisapi delete` or `nisapi.delete_cache()` to delete the cache, if needed
+1. This a poetry-enabled project. Use `poetry install` to install.
+2. [*optional*] Get a [Socrata app token](https://support.socrata.com/hc/en-us/articles/210138558-Generating-App-Tokens-and-API-Keys). This may speed up your downloads.
+3. See `scripts/demo.py` for an example of how to cache and query the data:
+   - `python -m nisapi cache` or `nisapi.cache_all_datasets()` to download, clean, and cache data. Add the command line or function argument `app_token={SOCRATA_APP_TOKEN}` to use the token.
+   - `nisapi.get_nis()` to get a lazy data frame pointing to that locally cached, clean data.
+   - `python -m nisapi delete` or `nisapi.delete_cache()` to delete the cache, if needed.
+
+Some more experimental options include:
+
 - See `scripts/demo_clean.py` for an example of a script that you could run while iteratively developing the cleaning code in `nisapi/clean/`.
-- See `scripts/demo_cloud.py` for a demo of how the data could be downloaded, cleaned, uploaded to Azure Blob Storage, and then downloaded from there. You will need to fill out the `azure:` keys in `secrets.yaml`.
+- See `scripts/demo_cloud.py` for a demo of how the data could be downloaded, cleaned, uploaded to Azure Blob Storage, and then downloaded from there. You will need to set up the environmental variables `AZURE_CLIENT_ID`, `AZURE_STORAGE_ACCOUNT_NAME`, `AZURE_CONTAINER_ID`, and `AZURE_BLOB_ROOT`.
 - Run `streamlit run scripts/demo_streamlit.py` to quickly query and visualize the data with a [streamlit](https://streamlit.io/) app.
 
 ## Data dictionary

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python API to access parts of the [National Immunization Survey](https://www.cdc
 - This a poetry-enabled project. Use `poetry install` to install.
 - Get a [Socrata app token](https://support.socrata.com/hc/en-us/articles/210138558-Generating-App-Tokens-and-API-Keys). Copy `scripts/secrets_template.yaml` to `scripts/secrets.yaml` and fill out the `app_token`.
 - See `scripts/demo.py` for an example of how to cache and query the data:
-  - `python -m nisapi cache` or `nisapi.cache_all_datasets()` to download, clean, and cache data
+  - `python -m nisapi cache app_token={SOCRATA_APP_TOKEN}` or `nisapi.cache_all_datasets(app_token={SOCRATA_APP_TOKEN})` to download, clean, and cache data
   - `nisapi.get_nis()` to get a lazy data frame pointing to that locally cached, clean data
   - `python -m nisapi delete` or `nisapi.delete_cache()` to delete the cache, if needed
 - See `scripts/demo_clean.py` for an example of a script that you could run while iteratively developing the cleaning code in `nisapi/clean/`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python API to access parts of the [National Immunization Survey](https://www.cdc
 - This a poetry-enabled project. Use `poetry install` to install.
 - Get a [Socrata app token](https://support.socrata.com/hc/en-us/articles/210138558-Generating-App-Tokens-and-API-Keys). Copy `scripts/secrets_template.yaml` to `scripts/secrets.yaml` and fill out the `app_token`.
 - See `scripts/demo.py` for an example of how to cache and query the data:
-  - `python -m nisapi cache_all` or `nisapi.cache_all_datasets()` to download, clean, and cache data
+  - `python -m nisapi cache` or `nisapi.cache_all_datasets()` to download, clean, and cache data
   - `nisapi.get_nis()` to get a lazy data frame pointing to that locally cached, clean data
   - `python -m nisapi delete` or `nisapi.delete_cache()` to delete the cache, if needed
 - See `scripts/demo_clean.py` for an example of a script that you could run while iteratively developing the cleaning code in `nisapi/clean/`.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Python API to access parts of the [National Immunization Survey](https://www.cdc
 - This a poetry-enabled project. Use `poetry install` to install.
 - Get a [Socrata app token](https://support.socrata.com/hc/en-us/articles/210138558-Generating-App-Tokens-and-API-Keys). Copy `scripts/secrets_template.yaml` to `scripts/secrets.yaml` and fill out the `app_token`.
 - See `scripts/demo.py` for an example of how to cache and query the data:
-  - `nisapi.cache_all_datasets()` to download, clean, and cache data
+  - `python -m nisapi cache_all` or `nisapi.cache_all_datasets()` to download, clean, and cache data
   - `nisapi.get_nis()` to get a lazy data frame pointing to that locally cached, clean data
-  - `nisapi.delete_cache()` to clear the cache, if needed
+  - `python -m nisapi clear` or `nisapi.delete_cache()` to clear the cache, if needed
 - See `scripts/demo_clean.py` for an example of a script that you could run while iteratively developing the cleaning code in `nisapi/clean/`.
 - See `scripts/demo_cloud.py` for a demo of how the data could be downloaded, cleaned, uploaded to Azure Blob Storage, and then downloaded from there. You will need to fill out the `azure:` keys in `secrets.yaml`.
 - Run `streamlit run scripts/demo_streamlit.py` to quickly query and visualize the data with a [streamlit](https://streamlit.io/) app.

--- a/nisapi/__main__.py
+++ b/nisapi/__main__.py
@@ -1,17 +1,45 @@
 import argparse
+from pathlib import Path
 
 import nisapi
 
 if __name__ == "__main__":
+    default_cache = nisapi._root_cache_path()
+
     p = argparse.ArgumentParser()
-    sp = p.add_subparsers(dest="subcommand")
-    sp.add_parser("cache", help="Cache all datasets")
-    sp.add_parser("delete", help="Delete all cached datasets")
+    p.add_argument("--path", type=Path, help=f"Path to cache. Default: {default_cache}")
+    sp = p.add_subparsers(dest="subcommand", required=True)
+    sp_cache = sp.add_parser("cache", help="Cache all datasets")
+    sp_cache.add_argument("--app_token", type=str, help="Socrata developer API token")
+    sp_cache.add_argument(
+        "--overwrite",
+        default="warn",
+        choices=["warn"],
+        help="Overwrite existing datasets? Only supported option is 'warn', "
+        "which prints a notice that a dataset is not overwritten.",
+    )
+    sp_cache.add_argument(
+        "--validate",
+        default="warn",
+        choices=["warn", "error", "ignore"],
+        help="How to handle validation problems?",
+    )
+    sp_delete = sp.add_parser("delete", help="Delete all cached datasets")
+    sp_delete.add_argument(
+        "--force",
+        action="store_true",
+        help="Confirm deletion of all cached datasets",
+    )
     args = p.parse_args()
 
     if args.subcommand == "cache_all":
-        nisapi.cache_all_datasets()
+        nisapi.cache_all_datasets(
+            path=args.path,
+            app_token=args.app_token,
+            overwrite=args.overwrite,
+            validation_mode=args.validate,
+        )
     elif args.subcommand == "delete":
-        nisapi.delete_cache()
+        nisapi.delete_cache(path=args.path, confirm=not args.force)
     else:
         p.print_help()

--- a/nisapi/__main__.py
+++ b/nisapi/__main__.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     )
     args = p.parse_args()
 
-    if args.subcommand == "cache_all":
+    if args.subcommand == "cache":
         nisapi.cache_all_datasets(
             path=args.path,
             app_token=args.app_token,
@@ -42,4 +42,5 @@ if __name__ == "__main__":
     elif args.subcommand == "delete":
         nisapi.delete_cache(path=args.path, confirm=not args.force)
     else:
+        print(f"Unknown subcommand: {args.subcommand}")
         p.print_help()

--- a/nisapi/__main__.py
+++ b/nisapi/__main__.py
@@ -5,7 +5,7 @@ import nisapi
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
     sp = p.add_subparsers(dest="subcommand")
-    sp.add_parser("cache_all", help="Cache all datasets")
+    sp.add_parser("cache", help="Cache all datasets")
     sp.add_parser("delete", help="Delete all cached datasets")
     args = p.parse_args()
 

--- a/nisapi/__main__.py
+++ b/nisapi/__main__.py
@@ -1,0 +1,17 @@
+import argparse
+
+import nisapi
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    sp = p.add_subparsers(dest="subcommand")
+    sp.add_parser("cache_all", help="Cache all datasets")
+    sp.add_parser("delete", help="Delete all cached datasets")
+    args = p.parse_args()
+
+    if args.subcommand == "cache_all":
+        nisapi.cache_all_datasets()
+    elif args.subcommand == "delete":
+        nisapi.clean_all_datasets()
+    else:
+        p.print_help()

--- a/nisapi/__main__.py
+++ b/nisapi/__main__.py
@@ -12,6 +12,6 @@ if __name__ == "__main__":
     if args.subcommand == "cache_all":
         nisapi.cache_all_datasets()
     elif args.subcommand == "delete":
-        nisapi.clean_all_datasets()
+        nisapi.delete_cache()
     else:
         p.print_help()

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -1,15 +1,17 @@
+import os
+
 import polars as pl
-import yaml
 
 import nisapi
 
-# Load secrets from a top-level file `secrets.yaml` with key `app_token`.
-with open("scripts/secrets.yaml") as f:
-    app_token = yaml.safe_load(f)["app_token"]
-
-# Clear and rebuild
+# Clear cache if needed
 # nisapi.delete_cache()
-nisapi.cache_all_datasets(app_token=app_token)
+
+# Check that the app token is present
+if "SOCRATA_APP_TOKEN" not in os.environ:
+    raise ValueError("SOCRATA_APP_TOKEN environment variable not found")
+
+nisapi.cache_all_datasets(app_token=os.environ["SOCRATA_APP_TOKEN"])
 
 # Pull a subset of the data that's currently available
 (

--- a/scripts/demo_cloud.py
+++ b/scripts/demo_cloud.py
@@ -1,11 +1,12 @@
-import yaml
 import os
+import tempfile
+from pathlib import Path
+
+import polars as pl
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient
-from pathlib import Path
+
 import nisapi
-import tempfile
-import polars as pl
 
 
 def get_client(client_id: str, storage_account_name: str) -> BlobServiceClient:
@@ -105,13 +106,9 @@ assert (
     == "nis/id=foo/bar.csv"
 )
 
-# get the service principal, etc.
-with open("scripts/secrets.yaml") as f:
-    secrets = yaml.safe_load(f)
-
 # set up and authenticate the client
 client = get_client(
-    secrets["azure"]["client_id"], secrets["azure"]["storage_account_name"]
+    os.environ["AZURE_CLIENT_ID"], os.environ["AZURE_STORAGE_ACCOUNT_NAME"]
 )
 
 # upload the blobs from local storage to remote, to demonstrate how a definitive
@@ -119,8 +116,8 @@ client = get_client(
 print("Uploading blobs")
 upload_blobs(
     client=client,
-    container_id=secrets["azure"]["container_id"],
-    blob_root=secrets["azure"]["blob_root"],
+    container_id=os.environ["AZURE_CONTAINER_ID"],
+    blob_root=os.environ["AZURE_BLOB_ROOT"],
     local_dir=nisapi._root_cache_path(),
 )
 
@@ -130,8 +127,8 @@ print("Downloading blobs")
 with tempfile.TemporaryDirectory() as tmpdir:
     download_blobs(
         client=client,
-        container_id=secrets["azure"]["container_id"],
-        blob_root=secrets["azure"]["blob_root"],
+        container_id=os.environ["AZURE_CONTAINER_ID"],
+        blob_root=os.environ["AZURE_BLOB_ROOT"],
         local_dir=tmpdir,
     )
 

--- a/scripts/secrets_template.yaml
+++ b/scripts/secrets_template.yaml
@@ -1,6 +1,0 @@
-app_token: <SOCRATA APP TOKEN>
-azure:
-  client_id: <MY SERVICE PRINCIPAL>
-  storage_account_name: <MY STORAGE ACCOUNT>
-  container_id: <MY CONTAINER>
-  blob_root: <ROOT OF THE CACHE DIRECTORY>


### PR DESCRIPTION
- Add a CLI: `python -m nisapi`
- Gated on #76  : pass top-level things like cache path, overwrite, and validation mode through that CLI
- Solves #74 : use environmental variables, rather than `secrets.yaml`