### PR TITLE
Validation problems and modes

### DIFF
--- a/nisapi/clean/__init__.py
+++ b/nisapi/clean/__init__.py
@@ -42,7 +42,7 @@ def clean_dataset(df: pl.DataFrame, id: str) -> pl.DataFrame:
 
 
 class Validate:
-    modes = ["warn", "fail", "ignore"]
+    modes = ["warn", "error", "ignore"]
 
     def __init__(self, id: str, df: pl.DataFrame | pl.LazyFrame, mode: str = "warn"):
         """Set up for validation
@@ -50,9 +50,9 @@ class Validate:
         Args:
             id (str): dataset ID, used for validation problem messaging
             df (pl.DataFrame | pl.LazyFrame): dataset to validate
-            mode (str): validation mode. One of "warn", "fail", "ignore". If ignore, do
+            mode (str): validation mode. One of "warn", "error", "ignore". If ignore, do
                 nothing on validation problems. If "warn", print a warning message. If
-                fail, raise an error.
+                error, raise an error.
         """
         self.id = id
         self.df = df.pipe(ensure_eager)
@@ -70,7 +70,7 @@ class Validate:
         if len(self.problems) > 0 and self.mode != "ignore":
             print("\n".join([f"❌ id={self.id}: {x}" for x in self.problems]))
 
-            if self.mode == "fail":
+            if self.mode == "error":
                 raise RuntimeError("Validation problems")
 
     @classmethod

--- a/nisapi/clean/__init__.py
+++ b/nisapi/clean/__init__.py
@@ -48,15 +48,18 @@ class Validate:
         self.validate()
 
     def validate(self):
-        self.errors = self.get_validation_errors(self.df)
-        if len(self.errors) > 0:
+        self.problems = self.get_validation_problems(self.df)
+        if len(self.problems["warnings"]) > 0:
+            print(f"Validation warnings in dataset ID: {self.id}")
+            print(*self.problems["warnings"], sep="\n")
+        if len(self.problems["errors"]) > 0:
             print(f"Validation errors in dataset ID: {self.id}")
-            print(*self.errors, sep="\n")
+            print(*self.problems["errors"], sep="\n")
 
             raise RuntimeError("Validation errors")
 
     @classmethod
-    def get_validation_errors(cls, df: pl.DataFrame):
+    def get_validation_problems(cls, df: pl.DataFrame):
         errors = []
         warnings = []
 
@@ -131,7 +134,7 @@ class Validate:
         if not ((df["lci"] <= df["estimate"]) & (df["estimate"] <= df["uci"])).all():
             errors.append("confidence intervals do not bracket estimate")
 
-        return errors
+        return {"errors": errors, "warnings": warnings}
 
     @staticmethod
     def validate_vaccine(df: pl.DataFrame, column: str) -> [str]:


### PR DESCRIPTION
- Rebased version and amended version #61
- There are no "errors" or "warnings," but just "problems".
- How you deal with that depends on the "mode" you are in:
  - ignore: do nothing
  - warn: print out the problems
  - error: print out the problems and throw an error

This approach differs from and extends #61: rather than making some validations into errors and some into warnings, whether you error or warn is a feature of the whole pipeline. This could one day get annoying if we have some things that are warning-worthy but we can't fix (e.g., the "NA" CIs in akkj), but I suggest we punt that until it's a real problem.

Resolves #63 