### PR TITLE
Make paths public

### DIFF
--- a/nisapi/__init__.py
+++ b/nisapi/__init__.py
@@ -24,7 +24,7 @@ def get_nis(path: Optional[Path] = None) -> pl.LazyFrame:
         pl.LazyFrame: _description_
     """
     if path is None:
-        path = Path(_root_cache_path(), "clean")
+        path = Path(root_cache_path(), "clean")
 
     return pl.scan_parquet(path)
 
@@ -47,7 +47,7 @@ def cache_all_datasets(
             Default ("warn") will print a warning and continue.
     """
     if path is None:
-        path = _root_cache_path()
+        path = root_cache_path()
 
     for id in _get_dataset_ids():
         _cache_clean_dataset(
@@ -69,7 +69,7 @@ def delete_cache(path: Optional[Path] = None, confirm: bool = True) -> None:
           confirmation before deleting
     """
     if path is None:
-        path = _root_cache_path()
+        path = root_cache_path()
 
     if not Path(path).exists():
         warnings.warn(f"Cache path {path} does not exist")
@@ -119,7 +119,7 @@ def _cache_clean_dataset(
     clean_data.write_parquet(clean_path)
 
 
-def _root_cache_path() -> Path:
+def root_cache_path() -> Path:
     return Path(platformdirs.user_cache_dir("nisapi"))
 
 

--- a/nisapi/__main__.py
+++ b/nisapi/__main__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import nisapi
 
 if __name__ == "__main__":
-    default_cache = nisapi._root_cache_path()
+    default_cache = nisapi.root_cache_path()
 
     p = argparse.ArgumentParser()
     p.add_argument("--path", type=Path, help=f"Path to cache. Default: {default_cache}")

--- a/scripts/demo_clean.py
+++ b/scripts/demo_clean.py
@@ -14,7 +14,7 @@ with open("scripts/secrets.yaml") as f:
     app_token = yaml.safe_load(f)["app_token"]
 
 raw = nisapi._get_nis_raw(
-    id=dataset_id, app_token=app_token, root_path=nisapi._root_cache_path()
+    id=dataset_id, app_token=app_token, root_path=nisapi.root_cache_path()
 )
 
 # show the first few rows of the raw data

--- a/scripts/demo_cloud.py
+++ b/scripts/demo_cloud.py
@@ -118,7 +118,7 @@ upload_blobs(
     client=client,
     container_id=os.environ["AZURE_CONTAINER_ID"],
     blob_root=os.environ["AZURE_BLOB_ROOT"],
-    local_dir=nisapi._root_cache_path(),
+    local_dir=nisapi.root_cache_path(),
 )
 
 # download the file to a new local directory, to demonstrate how another user


### PR DESCRIPTION
This PR makes the root and dataset cache paths public.

The motivation is from using this package in a snakemake pipeline. As snakemake needs to know where the dependencies are, these functions become useful outside the package.