### PR TITLE
Refactor cache path getting

### DIFF
--- a/nisapi/__init__.py
+++ b/nisapi/__init__.py
@@ -24,7 +24,7 @@ def get_nis(path: Optional[Path] = None) -> pl.LazyFrame:
         pl.LazyFrame: _description_
     """
     if path is None:
-        path = Path(_root_cache_path(), "clean")
+        path = Path(root_cache_path(), "clean")
 
     return pl.scan_parquet(path)
 
@@ -47,7 +47,7 @@ def cache_all_datasets(
             Default ("warn") will print a warning and continue.
     """
     if path is None:
-        path = _root_cache_path()
+        path = root_cache_path()
 
     for id in _get_dataset_ids():
         _cache_clean_dataset(
@@ -69,7 +69,7 @@ def delete_cache(path: Optional[Path] = None, confirm: bool = True) -> None:
           confirmation before deleting
     """
     if path is None:
-        path = _root_cache_path()
+        path = root_cache_path()
 
     if not Path(path).exists():
         warnings.warn(f"Cache path {path} does not exist")
@@ -119,7 +119,7 @@ def _cache_clean_dataset(
     clean_data.write_parquet(clean_path)
 
 
-def _root_cache_path() -> Path:
+def root_cache_path() -> Path:
     return Path(platformdirs.user_cache_dir("nisapi"))
 
 

--- a/nisapi/__init__.py
+++ b/nisapi/__init__.py
@@ -102,7 +102,7 @@ def _cache_clean_dataset(
     clean_data = nisapi.clean.clean_dataset(
         df=raw_data, id=id, validation_mode=validation_mode
     )
-    clean_path_dir = _dataset_cache_path(root_path=root_path, type_="clean", id=id)
+    clean_path_dir = dataset_cache_path(root_path=root_path, type_="clean", id=id)
     clean_path = clean_path_dir / "part-0.parquet"
 
     if clean_path.exists():
@@ -123,7 +123,7 @@ def root_cache_path() -> Path:
     return Path(platformdirs.user_cache_dir("nisapi"))
 
 
-def _dataset_cache_path(root_path: Path, type_: str, id: str) -> Path:
+def dataset_cache_path(root_path: Path, type_: str, id: str) -> Path:
     """Construct path to a particular dataset in the cache
 
     Cache starts at the "root", goes through either "raw" or "clean",
@@ -141,7 +141,7 @@ def _dataset_cache_path(root_path: Path, type_: str, id: str) -> Path:
 
 
 def _get_nis_raw(id: str, root_path: Path, app_token: Optional[str]) -> pl.LazyFrame:
-    dir_path = _dataset_cache_path(root_path=root_path, type_="raw", id=id)
+    dir_path = dataset_cache_path(root_path=root_path, type_="raw", id=id)
     path = dir_path / "part-0.parquet"
 
     if not dir_path.exists():

--- a/nisapi/__init__.py
+++ b/nisapi/__init__.py
@@ -2,8 +2,9 @@ import importlib.resources
 import shutil
 import tempfile
 import warnings
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Literal, Optional
 
 import platformdirs
 import polars as pl
@@ -99,7 +100,7 @@ def _cache_clean_dataset(
     validation_mode: str,
 ) -> None:
     raw_data_path = get_data_path(path=cache_path, type_="raw", id=id)
-    raw_data = _get_nis_raw(id=id, data_path=raw_data_path, app_token=app_token)
+    raw_data = _get_nis_raw(id=id, raw_data_path=raw_data_path, app_token=app_token)
     clean_data = nisapi.clean.clean_dataset(
         df=raw_data, id=id, validation_mode=validation_mode
     )
@@ -122,7 +123,7 @@ def _cache_clean_dataset(
 
 def get_data_path(
     path: Optional[Path] = None,
-    type_: str = "clean",
+    type_: Literal["clean", "raw"] = "clean",
     id: Optional[str] = None,
 ) -> Path:
     """
@@ -161,16 +162,19 @@ def default_cache_path() -> Path:
     return Path(platformdirs.user_cache_dir("nisapi"))
 
 
-def _get_nis_raw(id: str, data_path: Path, app_token: Optional[str]) -> pl.LazyFrame:
+def _get_nis_raw(
+    id: str, raw_data_path: Path, app_token: Optional[str]
+) -> pl.LazyFrame:
     """
     Args:
         id (str): dataset ID
-        path (Path): path to the raw dataset directory
+        raw_data_path (Path): path to the raw dataset directory
+        app_token (str, optional): Socrata developer API token, or None
     """
-    filepath = data_path / "part-0.parquet"
+    filepath = raw_data_path / "part-0.parquet"
 
-    if not data_path.exists():
-        data_path.mkdir(parents=True)
+    if not raw_data_path.exists():
+        raw_data_path.mkdir(parents=True)
 
     if not filepath.exists():
         data = _download_dataset(id=id, app_token=app_token)

--- a/nisapi/__main__.py
+++ b/nisapi/__main__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import nisapi
 
 if __name__ == "__main__":
-    default_cache = nisapi._root_cache_path()
+    default_cache = nisapi.root_cache_path()
 
     p = argparse.ArgumentParser()
     p.add_argument("--path", type=Path, help=f"Path to cache. Default: {default_cache}")

--- a/scripts/demo_clean.py
+++ b/scripts/demo_clean.py
@@ -14,7 +14,7 @@ with open("scripts/secrets.yaml") as f:
     app_token = yaml.safe_load(f)["app_token"]
 
 raw = nisapi._get_nis_raw(
-    id=dataset_id, app_token=app_token, root_path=nisapi._root_cache_path()
+    id=dataset_id, app_token=app_token, root_path=nisapi.root_cache_path()
 )
 
 # show the first few rows of the raw data

--- a/scripts/demo_clean.py
+++ b/scripts/demo_clean.py
@@ -1,21 +1,29 @@
+import tempfile
+from pathlib import Path
+
 import altair as alt
 import polars as pl
 import yaml
 
 import nisapi
-import nisapi.clean.k4cb_dxd7
+import nisapi.clean.vh55_3he6
 from nisapi.clean import Validate
 
-dataset_id = "k4cb-dxd7"
-clean_func = nisapi.clean.k4cb_dxd7.clean
-clean_tmp_path = "scripts/tmp_clean.parquet"
+dataset_id = "vh55-3he6"
+clean_func = nisapi.clean.vh55_3he6.clean
+
+td = tempfile.TemporaryDirectory()
 
 with open("scripts/secrets.yaml") as f:
     app_token = yaml.safe_load(f)["app_token"]
 
 raw = nisapi._get_nis_raw(
-    id=dataset_id, app_token=app_token, root_path=nisapi.root_cache_path()
+    id=dataset_id,
+    app_token=app_token,
+    data_path=Path(td.name),
 )
+
+print(f"Raw data saved to {td.name}")
 
 # show the first few rows of the raw data
 raw.head().collect().glimpse()
@@ -27,7 +35,9 @@ clean = clean_func(raw)
 clean.head(10).collect().glimpse()
 
 # save a copy of the partially cleaned data
-clean.collect().write_parquet(clean_tmp_path)
+tf = tempfile.NamedTemporaryFile()
+clean.collect().write_parquet(tf.name)
+print(f"Saved cleaned data to {tf.name}")
 
 # this will fail until the dataset cleaning is complete
 Validate(id=dataset_id, df=clean, mode="error")

--- a/scripts/demo_cloud.py
+++ b/scripts/demo_cloud.py
@@ -118,7 +118,7 @@ upload_blobs(
     client=client,
     container_id=os.environ["AZURE_CONTAINER_ID"],
     blob_root=os.environ["AZURE_BLOB_ROOT"],
-    local_dir=nisapi._root_cache_path(),
+    local_dir=nisapi.root_cache_path(),
 )
 
 # download the file to a new local directory, to demonstrate how another user

--- a/scripts/demo_cloud.py
+++ b/scripts/demo_cloud.py
@@ -118,7 +118,7 @@ upload_blobs(
     client=client,
     container_id=os.environ["AZURE_CONTAINER_ID"],
     blob_root=os.environ["AZURE_BLOB_ROOT"],
-    local_dir=nisapi.root_cache_path(),
+    local_dir=nisapi.default_cache_path(),
 )
 
 # download the file to a new local directory, to demonstrate how another user

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -4,12 +4,10 @@ import nisapi
 
 
 def test_default_cache_path():
-    path = nisapi.root_cache_path()
+    path = nisapi.default_cache_path()
     assert isinstance(path, Path)
 
 
 def test_dataset_cache_path():
-    path = nisapi.dataset_cache_path(
-        root_path=Path("fake_root"), type_="raw", id="1234"
-    )
+    path = nisapi.get_data_path(type_="raw", id="1234", path=Path("fake_root"))
     assert path == Path("fake_root", "raw", "id=1234")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -4,12 +4,12 @@ import nisapi
 
 
 def test_default_cache_path():
-    path = nisapi._root_cache_path()
+    path = nisapi.root_cache_path()
     assert isinstance(path, Path)
 
 
 def test_dataset_cache_path():
-    path = nisapi._dataset_cache_path(
+    path = nisapi.dataset_cache_path(
         root_path=Path("fake_root"), type_="raw", id="1234"
     )
     assert path == Path("fake_root", "raw", "id=1234")


### PR DESCRIPTION
- Top-level, public functions have an argument `path` that is always the cache root path
- `default_cache_path()` is public
- `get_data_path()` is public, to help people find their way to particular parts of the cache, without needing to know about the internal structure
- Lower-level, private functions refer to `cache_path` or `dataset_path` (which is root/raw/id=whatever or root/clean/id=whatever)