### PR TITLE
Add data set si7g-c2bs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Rows that were suppressed in the raw data are dropped. This includes data with s
 3. Create a dataset-specific module in `nisapi/clean/`. It should have a main function `clean()`.
    - Start with a `clean()` function that does nothing and just returns the input data frame.
 4. Add the `import` and `elif` statements for this dataset ID to `clean_dataset()` in `nisapi/clean/__init__.py`.
-5. Run `scripts/demo_clean.py`, after substituting the name of the dataset you are adding in Lines 6, 9, and 10. This should cache the raw dataset, run the cleaning function, and fail on validation.
+5. Run `scripts/demo_clean.py`, after substituting the name of the dataset you are adding in Lines 9, 12, and 13. This should cache the raw dataset, run the cleaning function, and fail on validation.
 6. Iteratively update the dataset-specific `clean()` function until validation passes.
    - Ideally, `clean()` should be a series of pipe functions.
    - If a cleaning step is specific to a single dataset, keep that in the dataset-specific submodule. If a step is shared between datasets, move it into `helpers.py`.

--- a/nisapi/clean/__init__.py
+++ b/nisapi/clean/__init__.py
@@ -6,6 +6,7 @@ import nisapi.clean.akkj_j5ru
 import nisapi.clean.k4cb_dxd7
 import nisapi.clean.ker6_gs6z
 import nisapi.clean.ksfb_ug5d
+import nisapi.clean.si7g_c2bs
 import nisapi.clean.sw5n_wg2p
 import nisapi.clean.vdz4_qrri
 import nisapi.clean.vh55_3he6
@@ -47,6 +48,8 @@ def clean_dataset(df: pl.LazyFrame, id: str, validation_mode: str) -> pl.DataFra
         out = nisapi.clean.vncy_2ds7.clean(df)
     elif id == "k4cb-dxd7":
         out = nisapi.clean.k4cb_dxd7.clean(df)
+    elif id == "si7g-c2bs":
+        out = nisapi.clean.si7g_c2bs.clean(df)
     else:
         raise RuntimeError(f"No cleaning set up for dataset {id}")
 

--- a/nisapi/clean/helpers.py
+++ b/nisapi/clean/helpers.py
@@ -160,6 +160,7 @@ def clean_geography(df: pl.LazyFrame) -> pl.LazyFrame:
                 "region": "region",
                 "substate": "substate",
                 "local": "local",
+                "hhs region": "region",
             }
         )
     )

--- a/nisapi/clean/si7g_c2bs.py
+++ b/nisapi/clean/si7g_c2bs.py
@@ -1,0 +1,5 @@
+import polars as pl
+
+
+def clean(df: pl.LazyFrame) -> pl.LazyFrame:
+    return df

--- a/nisapi/clean/si7g_c2bs.py
+++ b/nisapi/clean/si7g_c2bs.py
@@ -2,7 +2,6 @@ import polars as pl
 
 from nisapi.clean.helpers import (
     clamp_ci,
-    clean_4_level,
     clean_geography,
     drop_suppressed_rows,
     enforce_columns,
@@ -126,7 +125,6 @@ def clean(df: pl.LazyFrame) -> pl.LazyFrame:
         .pipe(clean_geography)
         .pipe(clean_regions)
         .pipe(clean_vaccine_names)
-        # .pipe(clean_4_level)
         .pipe(clamp_ci)
         .pipe(enforce_columns)
         .pipe(remove_duplicate_rows)

--- a/nisapi/clean/si7g_c2bs.py
+++ b/nisapi/clean/si7g_c2bs.py
@@ -1,5 +1,79 @@
 import polars as pl
 
+from nisapi.clean.helpers import (
+    clamp_ci,
+    clean_4_level,
+    clean_geography,
+    drop_suppressed_rows,
+    enforce_columns,
+    replace_overall_domain,
+    set_lowercase,
+)
+
+
+def rename_columns(df: pl.LazyFrame) -> pl.LazyFrame:
+    return df.rename(
+        {
+            "group_name": "domain_type",
+            "group_category": "domain",
+            "indicator_name": "indicator_type",
+            "indicator_category": "indicator",
+            "new_vax_group": "vaccine",
+        }
+    )
+
+
+def cast_numeric_types(df: pl.LazyFrame) -> pl.LazyFrame:
+    out = df.with_columns(
+        pl.col("estimate").cast(pl.Float64),
+        lci=pl.col("_95_ci").str.split("-").arr.first().cast(pl.Float64),
+        uci=pl.col("_95_ci").str.split("-").arr.last().cast(pl.Float64),
+    ).with_columns(
+        pl.col("estimate") / 100.0,
+        pl.col("lci") / 100.0,
+        pl.col("uci") / 100.0,
+    )
+
+    return out
+
+
+def cast_date_types(df: pl.LazyFrame) -> pl.LazyFrame:
+    out = (
+        df.with_columns(
+            time_start=pl.col("time_period")
+            .str.split("-")
+            .arr.first()
+            .str.strip_chars_end(),
+            time_end=pl.col("time_period")
+            .str.split("-")
+            .arr.last()
+            .str.strip_chars_end(),
+            time_type=pl.lit("month"),
+        )
+        .with_columns(
+            time_start=(pl.col("time_start") + " " + pl.col("year")),
+            time_end=(pl.col("time_end") + " " + pl.col("year")),
+        )
+        .with_columns(
+            pl.col("time_start").str.strptime(pl.Datetime, "%B %d %Y").dt.date(),
+            pl.col("time_end").str.strptime(pl.Datetime, "%B %d %Y").dt.date(),
+        )
+        .drop("year")
+    )
+
+    return out
+
 
 def clean(df: pl.LazyFrame) -> pl.LazyFrame:
-    return df
+    return (
+        df.pipe(drop_suppressed_rows)
+        .pipe(rename_columns)
+        .pipe(set_lowercase)
+        .pipe(cast_numeric_types)
+        .pipe(cast_date_types)
+        .pipe(clean_geography)
+        # .pipe(clean_4_level)
+        .pipe(clamp_ci)
+        .pipe(enforce_columns)
+        .pipe(replace_overall_domain)
+    )

--- a/nisapi/datasets.yaml
+++ b/nisapi/datasets.yaml
@@ -71,4 +71,11 @@
   notes:
     - The column "suppression_flag" is misspelled as "suppresion_flag"
     - The columns that are usually named "geographic_type" and "geographic_level" are instead "geography_type" and "geography_level"
-    - An "age_group" column, divides every entry into "60-74 years (high risk)" vs. "75+ years" even when "domain_type" is not "overall" i.e. age
+    - An "age_group" column, divides every entry into "60-74 years (high risk)" vs. "75+ years" even when "domain_type" is not "overall" i.e. age\
+- id: si7g-c2bs
+  url: https://data.cdc.gov/Vaccinations/National-Immunization-Survey-Adult-COVID-Module-NI/si7g-c2bs/about_data
+  vaccine: covid, flu, and rsv
+  start_date: 2024-09-01
+  universe: 18+ years old
+  notes:
+  - The data is monthly but includes the full cross of state-level geography and adult age groups for all three vaccinations, for 2024-25

--- a/scripts/demo_clean.py
+++ b/scripts/demo_clean.py
@@ -6,11 +6,11 @@ import polars as pl
 import yaml
 
 import nisapi
-import nisapi.clean.vh55_3he6
+import nisapi.clean.si7g_c2bs
 from nisapi.clean import Validate
 
-dataset_id = "vh55-3he6"
-clean_func = nisapi.clean.vh55_3he6.clean
+dataset_id = "si7g-c2bs"
+clean_func = nisapi.clean.si7g_c2bs.clean
 
 td = tempfile.TemporaryDirectory()
 

--- a/scripts/demo_clean.py
+++ b/scripts/demo_clean.py
@@ -31,6 +31,9 @@ raw.head().collect().glimpse()
 # try to clean the data
 clean = clean_func(raw)
 
+# TEMPORARY - Check schema
+print(clean.schema)
+
 # look at the first few rows of the partially cleaned data
 clean.head(10).collect().glimpse()
 

--- a/scripts/demo_clean.py
+++ b/scripts/demo_clean.py
@@ -31,9 +31,6 @@ raw.head().collect().glimpse()
 # try to clean the data
 clean = clean_func(raw)
 
-# TEMPORARY - Check schema
-print(clean.schema)
-
 # look at the first few rows of the partially cleaned data
 clean.head(10).collect().glimpse()
 

--- a/scripts/demo_clean.py
+++ b/scripts/demo_clean.py
@@ -19,8 +19,8 @@ with open("scripts/secrets.yaml") as f:
 
 raw = nisapi._get_nis_raw(
     id=dataset_id,
+    raw_data_path=Path(td.name),
     app_token=app_token,
-    data_path=Path(td.name),
 )
 
 print(f"Raw data saved to {td.name}")


### PR DESCRIPTION
Data set si7g-c2bs has covid, flu, and rsv vaccination reported monthly for the full cross of state x age, as well as many other domains, for 2024-2025. There are two more similar data sets, for 2023-2024 and pre-2023, which are not included here. I have proposed elsewhere a refactor for the cleaning helpers, which I suggest we consider before investing effort in these other two data sets. But si7g-c2bs is already finished.

In addition to adding si7g-c2bs, I also fixed a few mistaken argument names for `._get_nis_raw` in the `demo_clean.py` script.