### PR TITLE
Enforce lowercase for domains and indicators

### DIFF
--- a/nisapi/clean/__init__.py
+++ b/nisapi/clean/__init__.py
@@ -127,6 +127,7 @@ class Validate:
         # whitespace
         for column in ["domain_type", "domain", "indicator_type", "indicator"]:
             problems += cls.validate_whitespace(df, column=column)
+            problems += cls.validate_capitals(df, column=column)
 
         # Vaccine -------------------------------------------------------------
         # `vaccine` must be in a certain set
@@ -280,7 +281,18 @@ class Validate:
             .to_list()
         )
 
-        return [f"Bad whitespace in column {column}: '{x}'" for x in bad_values]
+        return [f"Bad whitespace in column '{column}': '{x}'" for x in bad_values]
+
+    @classmethod
+    def validate_capitals(cls, df: pl.DataFrame, column: str) -> List[str]:
+        bad_values = (
+            df.select(pl.col(column).unique())
+            .filter(pl.col(column).pipe(cls._has_bad_capitals))
+            .to_series()
+            .to_list()
+        )
+
+        return [f"Bad capitals in column '{column}': '{x}'" for x in bad_values]
 
     @staticmethod
     def _has_excess_whitespace(x):

--- a/nisapi/clean/__init__.py
+++ b/nisapi/clean/__init__.py
@@ -127,7 +127,7 @@ class Validate:
         # whitespace
         for column in ["domain_type", "domain", "indicator_type", "indicator"]:
             problems += cls.validate_whitespace(df, column=column)
-            problems += cls.validate_capitals(df, column=column)
+            problems += cls.validate_capitalization(df, column=column)
 
         # Vaccine -------------------------------------------------------------
         # `vaccine` must be in a certain set
@@ -284,10 +284,10 @@ class Validate:
         return [f"Bad whitespace in column '{column}': '{x}'" for x in bad_values]
 
     @classmethod
-    def validate_capitals(cls, df: pl.DataFrame, column: str) -> List[str]:
+    def validate_capitalization(cls, df: pl.DataFrame, column: str) -> List[str]:
         bad_values = (
             df.select(pl.col(column).unique())
-            .filter(pl.col(column).pipe(cls._has_bad_capitals))
+            .filter(pl.col(column).pipe(cls._has_bad_capitalization))
             .to_series()
             .to_list()
         )
@@ -308,6 +308,10 @@ class Validate:
             | x.str.contains(r"^\s+")
             | x.str.contains(r"\s+$")
         )
+
+    @staticmethod
+    def _has_bad_capitalization(x):
+        return x.str.contains(r"[A-Z]+")
 
     @classmethod
     def validate_age_groups(cls, df) -> List[str]:

--- a/nisapi/clean/helpers.py
+++ b/nisapi/clean/helpers.py
@@ -210,6 +210,7 @@ def clean_domain_type(
         .pipe(_replace_column_values, "domain_type", lowercase, replace, append, infer)
         .pipe(_borrow_column_values, "domain_type", donor_colname, transfer)
         .pipe(_normalize_whitespace, "domain_type")
+        .pipe(_normalize_capitalization, "domain_type")
     )
 
     return df
@@ -237,6 +238,7 @@ def clean_domain(
         .pipe(_replace_column_values, "domain", lowercase, replace, append, infer)
         .pipe(_borrow_column_values, "domain", donor_colname, transfer)
         .pipe(_normalize_whitespace, "domain")
+        .pipe(_normalize_capitalization, "domain")
     )
 
     return df
@@ -263,6 +265,7 @@ def clean_indicator_type(
         )
         .pipe(_borrow_column_values, "indicator_type", donor_colname, transfer)
         .pipe(_normalize_whitespace, "indicator_type")
+        .pipe(_normalize_capitalization, "indicator_type")
     )
 
     return df
@@ -287,6 +290,7 @@ def clean_indicator(
         .pipe(_replace_column_values, "indicator", lowercase, replace, append, infer)
         .pipe(_borrow_column_values, "indicator", donor_colname, transfer)
         .pipe(_normalize_whitespace, "indicator")
+        .pipe(_normalize_capitalization, "indicator")
     )
 
     return df
@@ -717,6 +721,11 @@ def _normalize_whitespace(df: pl.LazyFrame, colname: str) -> pl.LazyFrame:
     return df.with_columns(
         pl.col(colname).str.strip_chars(characters=None).str.replace_all(r"\s+", " ")
     )
+
+
+def _normalize_capitalization(df: pl.LazyFrame, colname: str) -> pl.LazyFrame:
+    """Use lowercase everwhere"""
+    return df.with_columns(pl.col(colname).str.to_lowercase())
 
 
 def enforce_schema(df: pl.LazyFrame, schema: pl.Schema = data_schema) -> pl.LazyFrame:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -73,3 +73,12 @@ def test_has_excess_whitespace_df():
     v = Validate(id="test_df", df=df, mode="warn")
     assert len(v.problems) == 1
     assert "whitespace" in v.problems[0]
+
+
+def test_has_bad_capitalization():
+    assert Validate._has_bad_capitalization(
+        pl.Series(["I got a vaccine", "COVID-19"])
+    ).all()
+    assert (
+        Validate._has_bad_capitalization(pl.Series(["no problems here"])).not_().all()
+    )


### PR DESCRIPTION
The domain types, domains, indicator types, and indicators often have inconsistent capitalization that is difficult to predict. Make these lowercase always.

I considered 3 options:

1. Make these fields always uppercase.
   - Pro: Simple cleaning and validation.
   - Con: Ugly and antiquated.
2. Always lowercase
   - Pro: Also simple cleaning & validation. More modern standard.
   - Con: Ugly in a different way (e.g., `"u.s."` and `"i got vaccinated"` look weird). Potentially confusing (e.g., abbreviations like `"msa"`).
3. Make most things lowercase, unless they are special words.
   - Pro: Most intuitive for users
   - Con: Difficult to implement. See below.

At a quick glance, these "special words" would include: Hispanic, Spanish, English, Pacific Islander, Native Hawaiian, American Indian, Alaska Native, and multiple abbreviations like RSV, COVID-19, MSA, SVI, PI/NH, AIAN, and U.S.